### PR TITLE
feat: basic support for import.meta.resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Here comes this simple typescript AST transformer to the rescue.
 By using it "before" typescript transpilation, it will simply replace any "import.meta" expressions in typescript files by a mocked object.
 "import.meta" expressions are not compatible with *jest*, that by default, works in commonjs, so they need to be stripped down and replaced by a mocked object **before** typescript transpilation is done by *ts-jest*.
 
+There is a special basic support for `import.meta.resolve` function: mock can be done but argument value
+is ignored. Instead source filename can be used to provide different mock results for different cases.
+
  ### Configuration examples (**jest.config**) :
 > 📘 See *ts-jest* options documentation for more details about configuration  : https://kulshekhar.github.io/ts-jest/docs/getting-started/options
 
@@ -114,6 +117,16 @@ By using it "before" typescript transpilation, it will simply replace any "impor
         DEV: true
       },
       status: 2,
+      resolve: ({fileName}) => {
+        switch(basename(fileName)) {
+          case "test-module.ts":
+            return "https://www.mydummyurl.com/my.jpg";
+          case "test-module2.ts":
+            return "https://www.mydummyurl.com/my2.jpg";
+          default:
+            return "";
+        }
+      },
       file: ({fileName}) => fileName
     }
   ````
@@ -125,6 +138,16 @@ By using it "before" typescript transpilation, it will simply replace any "impor
       PROD: false,
       DEV: true
     },
+    resolve: () => {
+      switch(basename(fileName)) {
+        case "test-module.ts":
+          return "https://www.mydummyurl.com/my.jpg";
+        case "test-module2.ts":
+          return "https://www.mydummyurl.com/my2.jpg";
+        default:
+          return "";
+      }
+  },
     status: 2
   })
   ````

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
 import type { AstTransformer, JestConfigWithTsJest } from 'ts-jest';
 import { Options } from "./index";
+import { basename } from "path";
 
 const mockImportMetaTransformer: AstTransformer<Options> = {
   path: 'index.ts',
@@ -19,7 +20,18 @@ const mockImportMetaTransformer: AstTransformer<Options> = {
       },
       number: 333,
       expiration: () => new Date().getTime(),
-      flag: false
+      flag: false,
+      // NOTE: for resolve only static conversions based on source code filename are supported for now.
+      resolve: () => {
+        switch(basename(fileName)) {
+          case "test-module.ts":
+            return "https://www.mydummyurl.com/my.jpg";
+          default:
+            return "";
+        }
+      },
+      // NOTE: not supported:
+      // resolve: () => (moduleName: string)=>`https://www.mydummyurl.com/${moduleName.split("/").pop()}`,
     })
   }
 }

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -5,5 +5,5 @@ declare interface ImportMeta {
   number: number;
   expiration: number;
   flag: boolean;
+  resolve: (moduleName: string) => string;
 }
-

--- a/tests/test-module.spec.ts
+++ b/tests/test-module.spec.ts
@@ -47,3 +47,4 @@ describe('getResolve', () => {
     expect(getResolve()).toEqual('https://www.mydummyurl.com/my.jpg');
   });
 });
+

--- a/tests/test-module.spec.ts
+++ b/tests/test-module.spec.ts
@@ -47,4 +47,3 @@ describe('getResolve', () => {
     expect(getResolve()).toEqual('https://www.mydummyurl.com/my.jpg');
   });
 });
-

--- a/tests/test-module.spec.ts
+++ b/tests/test-module.spec.ts
@@ -1,4 +1,4 @@
-import { getEnv, getSpec, getFlag, getNumber, getUrl, getExpiration, getFileName } from './test-module';
+import { getEnv, getSpec, getFlag, getNumber, getUrl, getExpiration, getFileName, getResolve } from './test-module';
 
 describe('getUrl', () => {
   it('Should return replaced path.', () => {
@@ -39,5 +39,11 @@ describe('getNumber', () => {
 describe('getExpiration', () => {
   it('Should return a value < than current time.', () => {
     expect(getExpiration()).toBeLessThan(new Date().getTime());
+  });
+});
+
+describe('getResolve', () => {
+  it('Should return absolute URL for relative path to static file.', () => {
+    expect(getResolve()).toEqual('https://www.mydummyurl.com/my.jpg');
   });
 });

--- a/tests/test-module.ts
+++ b/tests/test-module.ts
@@ -25,3 +25,7 @@ export function getExpiration(): number {
 export function getFlag(): boolean {
   return import.meta.flag;
 }
+
+export function getResolve(): string {
+  return import.meta.resolve(`../../image.jpg`);
+}


### PR DESCRIPTION
With this MR it's possible to mock statements like like this:
```
var url = import.meta.resolve(`../../image.jpg`);
```

Currently, mock value is a string per source filename (it can be different in different source files but in the same source file it will return the same value regardless to argument).

There is branch for more complex function-based mock but it's not finished (I lost ideas how to do it): https://github.com/stepin/ts-jest-mock-import-meta/tree/dev/meta-resolve-support-2